### PR TITLE
`super` has to be treated slightly differently.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,16 @@ fn process(oracle_cmd: &str, p: &Path) -> u64 {
                     }
                     next_txt = try_txt;
                 }
-                _ => break,
+                _ => {
+                    if let PubKind::Super = next_kind {
+                        // If we're depubing a root module, then `super` is invalid, causing
+                        // the following (not entirely intuitive) error:
+                        //   there are too many leading `super` keywords
+                        // We still want to try Private visibility in such cases.
+                    } else {
+                        break;
+                    }
+                }
             }
             kind = next_kind;
         }


### PR DESCRIPTION
In a sub-module, `super` is inbetween `pub(crate)` and private visibility. However, `super` isn't valid in top-level modules. If you try using it in such cases you get an error:

```
There are too many leading `super` keywords
```

It's not a great error but it really means "you can't use `super` (or `super super` or ...) to reference beyond a top-level module".

This meant that depub missed depubing top-level modules properly. This commit fixes that.