### PR TITLE
Be stricter about which things will be considered `pub`.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,13 @@ fn process(oracle_cmd: &str, p: &Path) -> u64 {
                     continue;
                 }
             }
-        } else {
+        } else if m.end() + 1 < cur_txt.len()
+            && cur_txt[m.end()..].chars().next().map(|x| x.is_whitespace()) == Some(true)
+        {
             PubKind::Pub
+        } else {
+            i = m.end();
+            continue;
         };
         let mut next_txt = cur_txt.clone();
         let mut depubed = false;


### PR DESCRIPTION
This, for example, stops the literal string "public" in a comment being matched. It's still quite crude, but it does exclude some obvious things which can't be matches.

Intended to ameliorate https://github.com/softdevteam/depub/issues/9. @djc does this work for you? In particular, does it exclude things that _should_ be excluded while still including things that _should_ be included?